### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/manjunathreddyjo0455/ee44cac5-7ad9-450f-b9cb-7933563ed10e/8600036b-a503-4cda-80c6-bba5518a31c8/_apis/work/boardbadge/4b9b7b02-c224-49f7-91a9-3b7f1f5680f7)](https://dev.azure.com/manjunathreddyjo0455/ee44cac5-7ad9-450f-b9cb-7933563ed10e/_boards/board/t/8600036b-a503-4cda-80c6-bba5518a31c8/Microsoft.RequirementCategory)
 # vaccinemart2021
 This repo is for storing the source code written by devs for devopling vaccine mart


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/manjunathreddyjo0455/ee44cac5-7ad9-450f-b9cb-7933563ed10e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.